### PR TITLE
feat(version): allow optional bash script execution before releasing

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -45,6 +45,10 @@ on:
         required: false
         type: boolean
         default: false
+      pre-release-bash-script:
+        description: 'Optional script to be run before release'
+        required: false
+        type: string
     outputs:
       new_release_published:
         value: ${{ jobs.version.outputs.new_release_published }}
@@ -86,6 +90,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      # This step is needed if npm publish is used.
+      # If you need to build before publishing, you can use the prepublishOnly reserved script
+      # Todo: figure out how to choose
+      - name: Shell
+        if: ${{ pre-release-bash-script != '' }}
+        run: |
+            ${{ pre-release-bash-script }}
       - uses: cycjimmy/semantic-release-action@v3
         id: semantic
         with:


### PR DESCRIPTION
This is necessary for the teams who are also publishing npm packages as a part of this workflow.