### PR TITLE
Add long form sha tags to images built

### DIFF
--- a/.github/workflows/reusable_publish.yaml
+++ b/.github/workflows/reusable_publish.yaml
@@ -87,7 +87,7 @@ jobs:
         with:
           tags: | 
             type=semver,pattern={{version}},value=${{inputs.version}}
-            type=sha
+            type=sha,format=long
           images: ${{ inputs.acr-server}}/${{ inputs.image-name }}
       - name: JFrog Login (needed for Flow builder)
         uses: azure/docker-login@v1


### PR DESCRIPTION
It might be very useful using longform shas to references images in the future. This PR's just adds long form sha to the tags on the acr (was short form).

