### PR TITLE
Fail snyk on upgradable

### DIFF
--- a/.github/workflows/reusable_report-snyk.yaml
+++ b/.github/workflows/reusable_report-snyk.yaml
@@ -60,7 +60,7 @@ jobs:
           snyk-version: v1.1035.0
       - name: Authenticate to Snyk
         run: snyk auth ${{ secrets.snyk-token }}
-      - name: Snyk dependencys test
+      - name: Snyk dependencies test
         run: snyk test --fail-on=upgradable --prune-repeated-subdependencies --json-file-output=snyk-report.json --org=${{ inputs.snyk-org }} ${{ inputs.snyk-test-additional-params }}
       - name: Convert to single root json
         run: |

--- a/.github/workflows/reusable_report-snyk.yaml
+++ b/.github/workflows/reusable_report-snyk.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Authenticate to Snyk
         run: snyk auth ${{ secrets.snyk-token }}
       - name: Snyk dependencys test
-        run: snyk test --fail-on=patchable --prune-repeated-subdependencies --json-file-output=snyk-report.json --org=${{ inputs.snyk-org }} ${{ inputs.snyk-test-additional-params }}
+        run: snyk test --fail-on=upgradable --prune-repeated-subdependencies --json-file-output=snyk-report.json --org=${{ inputs.snyk-org }} ${{ inputs.snyk-test-additional-params }}
       - name: Convert to single root json
         run: |
           jq '{"root": .}' <<< cat snyk-report.json >> results.json
@@ -74,6 +74,6 @@ jobs:
           username: ${{ secrets.acr-username }}
           password: ${{ secrets.acr-password }}
       - name: Snyk container test
-        run: snyk container test ${{ inputs.name }} --fail-on=patchable --json-file-output=snyk-container-report.json --org=${{ inputs.snyk-org }}
+        run: snyk container test ${{ inputs.name }} --fail-on=upgradable --json-file-output=snyk-container-report.json --org=${{ inputs.snyk-org }}
       - name: Report Snyk results to Kosli
         run: kosli pipeline artifact report evidence generic ${{ inputs.name }} -e code-security-scan --sha256 ${{ inputs.sha256 }} -u snyk-container-report.json


### PR DESCRIPTION
See discussion for background (https://github.com/stacc/github-workflow-actions/issues/6).

TL:DR;
Patching adds a layer of complexity for both the maintainers of the workflow, and the developers writing code using the workflow.
Sticking to only upgrading for now just works and is easier to understand for developers.