### PR TITLE
Allow specifying Dockerfile path in the publish workflow

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -82,6 +82,10 @@ on:
         required: false
         default: '.'
         type: string
+      docker-file:
+        description: 'Path to the Dockerfile. Default {docker-file-context}/Dockerfile'
+        type: string
+        required: false
     outputs:
       version:
         value: ${{ jobs.publish.outputs.version }}
@@ -107,6 +111,7 @@ jobs:
       image-name: ${{ inputs.image-name }}
       kosli-pipeline: ${{ inputs.kosli-pipeline }}
       docker-file-context: ${{ inputs.docker-file-context }}
+      docker-file: ${{ inputs.docker-file }}
       artifact-download-path: ${{ inputs.artifact-download-path }}
     secrets:
       acr-username: ${{ secrets.acr-username }}

--- a/.github/workflows/reusable_publish.yaml
+++ b/.github/workflows/reusable_publish.yaml
@@ -43,6 +43,9 @@ on:
         type: string
         required: false
         default: '.'
+      docker-file:
+        type: string
+        required: false
       artifact-download-path:
         type: string
         required: false
@@ -115,6 +118,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ${{ inputs.docker-file-context }}
+          file: ${{inputs.docker-file}}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docs/publish-image.md
+++ b/docs/publish-image.md
@@ -47,6 +47,8 @@ Secrets are inherited. Stacc Org secrets are used by default.
 | image                       | image name like 'services-someservice'         |                                                                       | yes      |
 | container-registry-host     | registry host                                  | stacc.azurecr.io                                                      | no       |
 | helm-repo                   | home of the helm charts                        | stacc                                                                 | no       |
+| docker-file-context         | Context for docker build                       | .                                                                     | no       |
+| docker-file                 | Path to the Dockerfile                         | ${{ docker-file-context }}/Dockerfile                                 | no       |
 | kosli-declare               | what types of evidence should we collect       | pull-request,artifact,test,container-security-scan,code-security-scan | no       |
 | kosli-pipeline              | Name of the Kosli pipeline                     | ${{inputs.image}}                                                     | no       |
 | kosli-owner                 | Name of the Kosli owner                        | stacc                                                                 | no       |


### PR DESCRIPTION
The publish workflow currently requires the `Dockerfile` to be found in `{docker-file-context}/Dockerfile`. This PR adds a new `docker-file` input, to specify a different file path. Preserves the old behavior if `docker-file` is not set.

I also tried documenting the `docker-file` and `docker-file-context` inputs. The rest of it seems pretty out of date, though.