### PR TITLE
fix(snyk): use tag and not name of image to scan. fix naming

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -159,7 +159,7 @@ jobs:
     needs: publish
     uses: stacc/github-workflow-actions/.github/workflows/reusable_report-snyk.yaml@main
     with:
-      name: ${{ needs.publish.outputs.name }}
+      name: ${{ needs.publish.outputs.image }}
       sha256: ${{ needs.publish.outputs.sha256 }}
       kosli-pipeline: ${{ inputs.kosli-pipeline }}
       snyk-org: ${{ inputs.snyk-org }}

--- a/.github/workflows/reusable_report-deployment.yaml
+++ b/.github/workflows/reusable_report-deployment.yaml
@@ -39,7 +39,7 @@ on:
         type: string
 
 jobs:
-  pull-request:
+  report-deployment:
     runs-on: ubuntu-latest
     steps:
       - uses: stacc/github-workflow-actions/actions/setup-kosli@main

--- a/.github/workflows/reusable_report-junit.yaml
+++ b/.github/workflows/reusable_report-junit.yaml
@@ -23,7 +23,7 @@ on:
         description: 'SHA256 of the published image'
         required: true
 jobs:
-  pull-request:
+  j-unit:
     runs-on: ubuntu-latest
     steps:
       - uses: stacc/github-workflow-actions/actions/setup-kosli@main

--- a/.github/workflows/reusable_report-junit.yaml
+++ b/.github/workflows/reusable_report-junit.yaml
@@ -23,7 +23,7 @@ on:
         description: 'SHA256 of the published image'
         required: true
 jobs:
-  j-unit:
+  report-j-unit:
     runs-on: ubuntu-latest
     steps:
       - uses: stacc/github-workflow-actions/actions/setup-kosli@main

--- a/.github/workflows/reusable_report-pull-request.yaml
+++ b/.github/workflows/reusable_report-pull-request.yaml
@@ -25,7 +25,7 @@ on:
         required: false
         type: string
 jobs:
-  pull-request:
+  report-pull-request:
     runs-on: ubuntu-latest
     steps:
       - uses: stacc/github-workflow-actions/actions/setup-kosli@main

--- a/.github/workflows/reusable_report-snyk.yaml
+++ b/.github/workflows/reusable_report-snyk.yaml
@@ -45,7 +45,7 @@ on:
         default: './'
 
 jobs:
-  snyk:
+  report-snyk:
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
- fixes names for jobs in reusables that were copy/pasted
- passes tag name to snyk job to allow container scanning of correct tag (altthough I assume it uses latest anyways)